### PR TITLE
Fix dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Remote Band.xcodeproj/xcuserdata/
-Remote Band.xcodeproj/project.xcworkspace/xcshareddata/
 Remote Band.xcodeproj/project.xcworkspace/xcuserdata/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ Remote Band.xcodeproj/xcuserdata/
 Remote Band.xcodeproj/project.xcworkspace/xcshareddata/
 Remote Band.xcodeproj/project.xcworkspace/xcuserdata/
 .DS_Store
-.gitmodules
-Frameworks/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Frameworks/MIKMIDI"]
+	path = Frameworks/MIKMIDI
+	url = https://github.com/mixedinkey-opensource/MIKMIDI.git

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the build process follow this steps:
 * Install **MIKMIDI** library (thanks [MIKMIDI] :blush: )
 ```sh
 cd remote-band
-git submodule add https://github.com/mixedinkey-opensource/MIKMIDI.git Frameworks/MIKMIDI
+git submodule init && git submodule update
 ```
 * Open ``remote-band.xcodeproj``
 * Press ``Build`` or ``⌘+B``

--- a/Remote Band.xcodeproj/xcshareddata/xcschemes/Remote Band.xcscheme
+++ b/Remote Band.xcodeproj/xcshareddata/xcschemes/Remote Band.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C85614D11B49C35C008945E8"
+               BuildableName = "Remote Band.app"
+               BlueprintName = "Remote Band"
+               ReferencedContainer = "container:Remote Band.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C85614D11B49C35C008945E8"
+            BuildableName = "Remote Band.app"
+            BlueprintName = "Remote Band"
+            ReferencedContainer = "container:Remote Band.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C85614D11B49C35C008945E8"
+            BuildableName = "Remote Band.app"
+            BlueprintName = "Remote Band"
+            ReferencedContainer = "container:Remote Band.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C85614D11B49C35C008945E8"
+            BuildableName = "Remote Band.app"
+            BlueprintName = "Remote Band"
+            ReferencedContainer = "container:Remote Band.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/remote-band/RemoteBandViewController.m
+++ b/remote-band/RemoteBandViewController.m
@@ -64,7 +64,7 @@
     if (!source) return;
     id token = [self.connectionTokensForSources objectForKey:source];
     if (!token) return;
-    [self.midiDeviceManager disconnectInput:source forConnectionToken:token];
+    [self.midiDeviceManager disconnectConnectionForToken:token];
 }
 
 - (void)connectToDevice:(MIKMIDIDevice *)device


### PR DESCRIPTION
First of all, thanks for this workaround of GarageBand which adds missing control messages handling! 😎

When using submodules, you should commit `.gitmodules` and submodule file so the commit hash persist, so other users of your app will get tested and working version of dependencies. Look, MIKMIDI API already changed! Fortunately, MIKMIDI maintaners seems to be good guys because they do not threw old API but marked as deprecated (and even kept functionality working!). So I made submodule reference to be part of the project and fixed deprecated thing. 

Alternative is using package manager like CocoaPods or Carthage – both supported by MIKMIDI, but requires package manager installed, while git is already installed :)

Scheme should be committed too, because it's basically an instruction for the Xcode which targets to build, and which are essential.